### PR TITLE
Add rfd deps and link to alternate implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,22 @@ The web application can be accessed here:
 
 https://woelper.github.io/egui_pick_file/
 
-
 For native:
+
+On linux install dependencies of [rfd](https://docs.rs/rfd/latest/rfd/index.html) as applicable.
+Copied from https://docs.rs/rfd/latest/rfd/#linux--bsd-backends
+
+> GTK backend is used with the `gtk3` Cargo feature which is enabled by default. The GTK3
+> backend requires the C library and development headers to be installed to build RFD. The package
+> names on various distributions are:
+> | Distribution | Installation Command |
+> | --------------- | ------------ |
+> | Fedora | dnf install gtk3-devel |
+> | Arch | pacman -S gtk3 |
+> | Debian & Ubuntu | apt install libgtk-3-dev |
+
 `cargo run`
+
 
 For web:
 
@@ -17,3 +30,5 @@ For web:
 `cargo install --locked trunk`
 
 `trunk serve --open`
+
+There is also an alternate example implementation that uses [poll-promise](https://docs.rs/poll-promise/latest/poll_promise/) instead available [here](https://github.com/c-git/egui_file_picker_poll_promise)https://github.com/c-git/egui_file_picker_poll_promise.


### PR DESCRIPTION
Hi,

Was going to create an issue to ask you before creating the pull request but since it was not much effort to make the PR I just did that and said we should be able to discuss here.

I created a version of your example that uses [poll-promise](https://docs.rs/poll-promise/latest/poll_promise/) and wanted to find out if you wouldn't mind linking to it so it's more discoverable. I figured yours is simpler to understand so I didn't want to replace yours hence why I made a separate one. 

In doing that I had to fix the CI issues again and figured maybe ppl might have the issue locally as well. I didn't but I maybe already had the dependency installed. So I added it to the readme in mine and included the change I made to this PR.

Let me know what you think. 

Thanks